### PR TITLE
Integration Fixes for Web Based Controllers

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1064,8 +1064,8 @@ var stl = 'stl/StressTest.stl';
 //var stl = 'stl/SLAcer.stl';
 
 // File url
-var url = 'http://' + window.location.hostname + window.location.pathname + stl;
-
+// var url = 'http://' + window.location.hostname + window.location.pathname + stl;
+var url = window.location.href + stl;
 // Create http request object
 var xmlhttp = new XMLHttpRequest();
 

--- a/js/main.js
+++ b/js/main.js
@@ -681,7 +681,7 @@ function updateBuildVolumeSettings() {
     });
 
     viewer3d.setBuildVolume(settings.get('buildVolume'));
-    viewer3d.dropObject(slicer.mesh);
+    slicer.mesh && viewer3d.dropObject(slicer.mesh);
     viewer3d.render();
 
     size && updateMeshInfoUI();


### PR DESCRIPTION
Two small fixes:
- Null check so that updateBuildVolumeSettings() will work even when a mesh hasn't been loaded yet (fixing a null pointer exception when slicer.mesh is null).
- Use `window.location.href` instead of concatenating hostname and pathname so that the default URL path will work for https and when the server is listening on something other than port 80.

The rest of the integration we are doing in a separate JS file that will call into the existing functions to pull calibration information and add functionality by modifying the DOM in code. You can see that in https://github.com/Kudo3D/SLAcer.js/blob/gh-pages/js/photonic3d.js

This can be a basis for lautr3k#10.
