### PR TITLE
Added zero padding for the PNG files within the zip

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -184,7 +184,7 @@ function getSlice(layerNumber) {
         sliceImage(dataURL);
 
         if (PNGExport) {
-            var fileName = layerNumber + '.png';
+            var fileName = layerNumber.toString().padStart(4, '0') + '.png';
             var imgData  = dataURL.substr(dataURL.indexOf(',') + 1);
             zipFolder.file(fileName, imgData, { base64: true });
         }


### PR DESCRIPTION
A quick change to add zero padding to fix an issue I had with the T3D printer needing the files to be in numeric order with padding.